### PR TITLE
UTCA-7: Re-establish MySQL DB relationship.

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -47,8 +47,8 @@ hooks:
 # The left-hand side is the name of the relationship as it will be exposed
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
-#relationships:
-#  database: "db:mysql"
+relationships:
+  database: "db:mysql"
 #  rediscache: "cache:redis"
 #  redissession: "cache:redis"
 

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,0 +1,6 @@
+db:
+  type: mariadb:10.11
+  disk: 512
+
+#cache:
+#  type: redis:6.4


### PR DESCRIPTION
MySQL is standard/default for Laravel; Upsun/PSH builds will show an error if it's not included.